### PR TITLE
Adds support for a python callback on IGV trackclick event

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,41 @@ Displaying the current IGV view as an SVG is simple - and only requires one call
 igv.get_svg()
 ```
 
+### Track-click handler
+
+The default IGV track-click popup – that lists annotation details for a GFF track for example –
+will probably be truncated by the edges of a notebook cell.
+You might also want to use a Python callback to do something when a track region is clicked:
+for example perform a computation, call an API, or render another widget.
+
+The IGV widget's trait `selectedTrackData` allows this.
+
+Example:
+
+```python
+igv.popupDisabled = True
+#(click on a track region)
+print(igv.selectedTrackData)
+```
+
+Or to render a Pandas dataframe in sync with the trackdata region:
+```python
+import pandas as pd
+
+igv = ...
+
+igv.popupDisabled = False
+
+details_widget = widgets.Output(layout={'border': '1px solid black'})
+@details_widget.capture(clear_output=True)
+def handle_track_click(track_data_change_event):
+    df = pd.DataFrame(track_data_change_event['new'])
+    display(df)
+
+igv.observe(handle_track_click, names='selectedTrackData')
+
+widgets.VBox([igv, details_widget])
+```
 
 ## Development Installation
 

--- a/igv_jupyterlab/igv_widget.py
+++ b/igv_jupyterlab/igv_widget.py
@@ -5,7 +5,7 @@ import random
 from functools import partial
 from ipywidgets import Output, DOMWidget
 from typing_extensions import TypedDict
-from traitlets import Unicode, Dict, Bunch
+from traitlets import Unicode, Dict, Bunch, Callable, List as TList, Bool
 from IPython.display import SVG, display
 from typing import List, Optional, Any, Union
 from ._frontend import module_name, module_version
@@ -70,12 +70,14 @@ class IGV(DOMWidget):
     initialConfig = Dict().tag(sync=True)
     locus = Unicode().tag(sync=True)
     svg = Unicode().tag(sync=True)
+    selectedTrackData = TList().tag(sync=True)
+    popupDisabled = Bool().tag(sync=True)
 
     def __init__(
         self, 
         genome: Union[str, Reference], 
         locus: str = None,
-        tracks: List[Dict] = None # Should be List[Track] ideally, see top
+        tracks: List[Dict] = None # Should be List[Track] ideally, see top,
         ):
         """
         Initialises an IGV browser instance. Basic information is
@@ -100,7 +102,7 @@ class IGV(DOMWidget):
             "id": self.id, 
             "locus": self.locus, 
             "tracks": tracks, 
-            "genome" if isinstance(genome, str) else "reference": genome
+            "genome" if isinstance(genome, str) else "reference": genome,
         })
 
     def _gen_id(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@epi2melabs/igv-jupyterlab",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@epi2melabs/igv-jupyterlab",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyter-widgets/base": "^1.1.10 || ^2.0.0 || ^3.0.0 || ^4.0.0",

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -9,45 +9,45 @@ import igv from 'igv';
 import { MODULE_NAME, MODULE_VERSION } from './version';
 
 if (!igv.browserCache) {
-  igv.browserCache = {}
+  igv.browserCache = {};
 }
 
 interface ICustomMessage {
-  type: string,
-  [x: string]: any
+  type: string;
+  [x: string]: any;
 }
 
 interface IBrowserTrack {
-  name: string,
-  url: string,
-  [x: string]: any
+  name: string;
+  url: string;
+  [x: string]: any;
 }
 
 interface IBrowserGenome {
-  id: string,
-  name: string,
-  fastaURL: string,
-  indexed: boolean,
-  indexURL?: string,
-  aliasURL?: string,
-  cytobandURL?: string,
-  tracks?: IBrowserTrack[]
+  id: string;
+  name: string;
+  fastaURL: string;
+  indexed: boolean;
+  indexURL?: string;
+  aliasURL?: string;
+  cytobandURL?: string;
+  tracks?: IBrowserTrack[];
 }
 
 interface IBrowserOptions {
-  id: string,
-  tracks: IBrowserTrack[],
-  locus: string,
+  id: string;
+  tracks: IBrowserTrack[];
+  locus: string;
 }
 
 interface IBrowserOptionsGenome extends IBrowserOptions {
-  genome: string,
-  reference?: never,
+  genome: string;
+  reference?: never;
 }
 
 interface IBrowserOptionsReference extends IBrowserOptions {
-  genome?: never,
-  reference: IBrowserGenome,
+  genome?: never;
+  reference: IBrowserGenome;
 }
 
 export class IGVModel extends DOMWidgetModel {
@@ -80,114 +80,126 @@ export class IGVMainView extends DOMWidgetView {
 
   render() {
     // Load initial config to hydrate browser
-    this.options = this.model.get('initialConfig')
+    this.options = this.model.get('initialConfig');
 
     // Create the IGV.js browser in this view
-    this.createBrowser(this.el)
+    this.createBrowser(this.el);
 
     // Handle updating managed state
     this.model.on('change:locus', this.locus_changed, this);
 
     // Handle RPC-like method calls from the backend
-    this.model.on("msg:custom", this.handle_custom_messages, this);
-    this.model.on("removeTrack", this.removeTrack, this);
-    this.model.on("loadTrack", this.loadTrack, this);
-    this.model.on("loadGenome", this.loadGenome, this);
-    this.model.on("remove", this.removeBrowser, this);
-    this.model.on("create", this.createBrowser, this);
-    this.model.on("zoomIn", this.zoomIn, this);
-    this.model.on("zoomOut", this.zoomOut, this);
-    this.model.on("toSVG", this.toSVG, this);
+    this.model.on('msg:custom', this.handle_custom_messages, this);
+    this.model.on('removeTrack', this.removeTrack, this);
+    this.model.on('loadTrack', this.loadTrack, this);
+    this.model.on('loadGenome', this.loadGenome, this);
+    this.model.on('remove', this.removeBrowser, this);
+    this.model.on('create', this.createBrowser, this);
+    this.model.on('zoomIn', this.zoomIn, this);
+    this.model.on('zoomOut', this.zoomOut, this);
+    this.model.on('toSVG', this.toSVG, this);
   }
 
   // State update methods
   locus_changed = () => {
-    const browser = this.getBrowser(this.options.id)
-    browser.search(this.model.get('locus'))
-  }
+    const browser = this.getBrowser(this.options.id);
+    browser.search(this.model.get('locus'));
+  };
 
   // RPC-like methods
   handle_custom_messages = (msg: ICustomMessage) => {
     const { type, ...obj } = msg;
-    this.model.trigger(type, obj)
-  }
+    this.model.trigger(type, obj);
+  };
 
   removeTrack = ({ name }: { name: string }) => {
-    const browser = this.getBrowser(this.options.id)
+    const browser = this.getBrowser(this.options.id);
     if (browser) {
-      browser.removeTrackByName(name)
+      browser.removeTrackByName(name);
     }
-  }
+  };
 
   loadTrack = ({ track }: { track: IBrowserTrack }) => {
-    const browser = this.getBrowser(this.options.id)
+    const browser = this.getBrowser(this.options.id);
     if (browser) {
-      browser.loadTrack(track)
+      browser.loadTrack(track);
     }
-  }
+  };
 
   loadGenome = ({ genome }: { genome: IBrowserGenome }) => {
-    const browser = this.getBrowser(this.options.id)
+    const browser = this.getBrowser(this.options.id);
     if (browser) {
-      browser.loadGenome(genome)
+      browser.loadGenome(genome);
     }
-  }
+  };
 
   zoomIn = () => {
-    const browser = this.getBrowser(this.options.id)
+    const browser = this.getBrowser(this.options.id);
     if (browser) {
-      browser.zoomIn()
+      browser.zoomIn();
     }
-  }
+  };
 
   zoomOut = () => {
-    const browser = this.getBrowser(this.options.id)
+    const browser = this.getBrowser(this.options.id);
     if (browser) {
-      browser.zoomOut()
+      browser.zoomOut();
     }
-  }
+  };
 
   toSVG = () => {
-    const browser = this.getBrowser(this.options.id)
+    const browser = this.getBrowser(this.options.id);
     if (browser) {
-      const svg = browser.toSVG()
-      this.model.set('svg', svg)
+      const svg = browser.toSVG();
+      this.model.set('svg', svg);
       this.model.save_changes();
     }
-  }
+  };
 
   // Browser instance management methods
   createBrowser = (div: HTMLElement) => {
     const id = this.options.id;
     if (igv.browserCache[id]) {
-      console.log(`Browser for this ID (${id}) already exists`)
-      return
+      console.log(`Browser for this ID (${id}) already exists`);
+      return;
     }
-    igv.createBrowser(div, this.options)
-      .then(function (browser: any) {
-        igv.browserCache[id] = browser;
-      })
-  }
+    igv.createBrowser(div, this.options).then((browser: any) => {
+      igv.browserCache[id] = browser;
+      console.log('created IGV');
+      this.setTrackClickHandler();
+    });
+  };
 
   removeBrowser = () => {
     if (document.getElementById(this.el.id)) {
-      this.el.parentNode?.removeChild(this.el)
+      this.el.parentNode?.removeChild(this.el);
     }
     const id = this.options.id;
     if (igv.browserCache[id]) {
-      delete igv.browserCache[id]
+      delete igv.browserCache[id];
     }
-  }
+  };
 
   getBrowser = (id: string) => {
-    return igv.browserCache[id]
-  }
+    return igv.browserCache[id];
+  };
 
   useBrowserMethod = (method: string) => {
-    const browser = this.getBrowser(this.options.id)
+    const browser = this.getBrowser(this.options.id);
     if (browser) {
-      browser[method]()
+      browser[method]();
     }
+  };
+
+  setTrackClickHandler = () => {
+    const browser = this.getBrowser(this.options.id);
+    browser.on('trackclick', (track: IBrowserTrack, trackData: any[]) => {
+      this.model.set('selectedTrackData', trackData.filter((item) => typeof item !== 'string'));
+      this.model.save_changes();
+      if (this.model.get('popupDisabled')) {
+        return false;
+      }
+    });
   }
 
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop":true,
-    "lib": ["es2015", "dom"],
+    "lib": ["es2017", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,


### PR DESCRIPTION
This pull request:
- adds a `trackclick` IGV event handler so that a track region / annotation data can be used in a callback
- adds a synced trait (`selectedTrackData`) that is updated when a `trackclick` happens
- adds an option (trait) `popupDisabled` that turns off the default IGV track-click popup (since it is usually truncated by the notebook cell borders anyway, and since it isn't useful if the user is doing a custom callback
- adds instructions to README about setting up interacting Widgets, e.g. to render the trackdata popup as a Pandas dataframe alongside the IGV widget
- includes a bit of code linting

Screenshot example:
<img width="1599" alt="image" src="https://user-images.githubusercontent.com/414767/201150294-0098cb54-3848-41d5-b126-80123dff0a88.png">
